### PR TITLE
Move test env var from workflow to .env file

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -17,13 +17,15 @@ jobs:
       run: npm install -g pnpm && pnpm install
     - name: Install Playwright Browsers
       run: pnpm exec playwright install --with-deps
+    - name: create env file
+      run: |
+        touch .env
+        echo IS_AUTOMATED_TEST=true >> .env
     - name: Build the application
       run: pnpm build
     - name: Start the application
       run: pnpm start & npx -y wait-on http://localhost:3000  
     - name: Run Playwright tests
-      env:
-        IS_AUTOMATED_TEST: true
       run: pnpm exec playwright test
     - uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}


### PR DESCRIPTION
Changes how the IS_AUTOMATED_TEST environment variable is provided to Playwright tests:
- Removes it from the workflow's env context
- Creates a .env file with the variable during test setup

This improves test configuration management by keeping environment variables in a dedicated file.
